### PR TITLE
Implement `dhstore` CLI command and containerize it

### DIFF
--- a/.github/workflows/publish-ecr.yml
+++ b/.github/workflows/publish-ecr.yml
@@ -1,0 +1,45 @@
+name: ECR
+
+on:
+  release:
+    types:
+      - published
+  push:
+    branches:
+      - main
+
+jobs:
+  publisher:
+    if: ${{ github.event.pusher.name != 'sti-bot' }}
+    name: Publish
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    env:
+      ECR_REGISTRY: 407967248065.dkr.ecr.us-east-2.amazonaws.com/ipni
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Determine Container Tag
+        run: |
+          IMAGE_TAG="${GITHUB_REF#refs/tags/v}"
+          if test "${IMAGE_TAG}" = "${GITHUB_REF}"; then
+            IMAGE_TAG="$(date '+%Y%m%d%H%M%S')-${GITHUB_SHA}"
+          fi
+          echo "Using image tag: ${IMAGE_TAG}"
+          echo "IMAGE_TAG=${IMAGE_TAG}" >> $GITHUB_ENV
+      - name: AWS Login
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-region: us-east-2
+          role-to-assume: "arn:aws:iam::407967248065:role/common/github_actions"
+          role-duration-seconds: 1200
+      - name: Login to Amazon ECR
+        run: aws ecr get-login-password | docker login --username AWS --password-stdin ${ECR_REGISTRY}
+      - name: Publish Container Image
+        run: |
+          IMAGE_NAME="${ECR_REGISTRY}/dhstore:${IMAGE_TAG}"
+          docker build -t "${IMAGE_NAME}" .
+          docker push "${IMAGE_NAME}"
+          echo "Published image ${IMAGE_NAME}"

--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -1,0 +1,41 @@
+name: Publish
+
+on:
+  release:
+    types:
+      - published
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    name: Container
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          tags: |
+            type=semver,pattern={{version}}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM golang:1.19-bullseye as build
+
+WORKDIR /go/src/dhstore
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+RUN CGO_ENABLED=0 go build -o /go/bin/dhstore ./cmd/dhstore
+
+FROM gcr.io/distroless/static-debian11
+COPY --from=build /go/bin/dhstore /usr/bin/
+
+ENTRYPOINT ["/usr/bin/dhstore"]

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,229 @@
+The contents of this repository are Copyright (c) corresponding authors and
+contributors, licensed under the `Permissive License Stack` meaning either of:
+
+- Apache-2.0 Software License: https://www.apache.org/licenses/LICENSE-2.0
+  ([...4tr2kfsq](https://dweb.link/ipfs/bafkreiankqxazcae4onkp436wag2lj3ccso4nawxqkkfckd6cg4tr2kfsq))
+
+- MIT Software License: https://opensource.org/licenses/MIT
+  ([...vljevcba](https://dweb.link/ipfs/bafkreiepofszg4gfe2gzuhojmksgemsub2h4uy2gewdnr35kswvljevcba))
+
+You may not use the contents of this repository except in compliance
+with one of the listed Licenses. For an extended clarification of the
+intent behind the choice of Licensing please refer to
+https://protocol.ai/blog/announcing-the-permissive-license-stack/
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the terms listed in this notice is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+either express or implied. See each License for the specific language
+governing permissions and limitations under that License.
+
+<!--- SPDX-License-Identifier: Apache-2.0 OR MIT -->
+`SPDX-License-Identifier: Apache-2.0 OR MIT`
+
+Verbatim copies of both licenses are included below:
+
+<details><summary>Apache-2.0 Software License</summary>
+
+```
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+```
+</details>
+
+<details><summary>MIT Software License</summary>
+
+```
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+```
+</details>

--- a/README.md
+++ b/README.md
@@ -1,2 +1,51 @@
-# dhstore
-Service to store double hashed indexed records
+# :lock_with_ink_pen: `dhstore`
+
+[![Build](https://github.com/ipni/dhstore/actions/workflows/test.yml/badge.svg)](https://github.com/ipni/dhstore/actions/workflows/test.yml)
+
+A Service to store double hashed indexed records with their corresponding encrypted values backed by
+Pebble key-value store according to
+the [IPNI Reader Privacy specification](https://github.com/ipni/specs/pull/5).
+
+The service exposes a HTTP API that allows clients to `PUT` or `GET` encrypted index value keys, as
+well as encrypted IPNI metadata.
+
+## Usage
+
+The repository provides a CLI command to start up the `dhstore` service, with following usage:
+
+```shell
+$ dhstore -h
+Usage of dhstore
+  -disableWAL
+        Weather to disable WAL in Pebble dhstore.
+  -listenAddr string
+        The dhstore HTTP server listen address. (default "0.0.0.0:40080")
+  -logLevel string
+        The logging level. Only applied if GOLOG_LOG_LEVEL environment variable is unset. (default "info")
+  -storePath string
+        The path at which the dhstore data persisted. (default "./dhstore/store")
+```
+
+## Run Server Locally
+
+To run the server locally, execute:
+
+```shell
+$ go run cmd/dhstore/main.go
+```
+
+The above command starts the HTTP API exposed on default listen address: `http://localhost:40080`
+
+For more information
+
+## Install
+
+To install `dhstore` CLI directly via Golang, run:
+
+```shell
+$ go install github.com/ipni/dhstore/cmd/dhstore@latest
+```
+
+## License
+
+[SPDX-License-Identifier: Apache-2.0 OR MIT](LICENSE.md)

--- a/cmd/dhstore/main.go
+++ b/cmd/dhstore/main.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"time"
+
+	"github.com/cockroachdb/pebble"
+	"github.com/cockroachdb/pebble/bloom"
+	logging "github.com/ipfs/go-log/v2"
+	"github.com/ipni/dhstore"
+)
+
+var (
+	log = logging.Logger("cmd/dhstore")
+)
+
+func main() {
+	storePath := flag.String("storePath", "./dhstore/store", "The path at which the dhstore data persisted.")
+	listenAddr := flag.String("listenAddr", "0.0.0.0:40080", "The dhstore HTTP server listen address.")
+	dwal := flag.Bool("disableWAL", false, "Weather to disable WAL in Pebble dhstore.")
+	llvl := flag.String("logLevel", "info", "The logging level. Only applied if GOLOG_LOG_LEVEL environment variable is unset.")
+	flag.Parse()
+
+	if _, set := os.LookupEnv("GOLOG_LOG_LEVEL"); !set {
+		_ = logging.SetLogLevel("*", *llvl)
+	}
+
+	// Default options copied from cockroachdb with the addition of 1GiB cache.
+	// See:
+	// - https://github.com/cockroachdb/cockroach/blob/v22.1.6/pkg/storage/pebble.go#L479
+	opts := &pebble.Options{
+		BytesPerSync:                10 << 20, // 10 MiB
+		WALBytesPerSync:             10 << 20, // 10 MiB
+		MaxConcurrentCompactions:    10,
+		MemTableSize:                64 << 20, // 64 MiB
+		MemTableStopWritesThreshold: 4,
+		LBaseMaxBytes:               64 << 20, // 64 MiB
+		L0CompactionThreshold:       2,
+		L0StopWritesThreshold:       1000,
+		DisableWAL:                  *dwal,
+		WALMinSyncInterval:          func() time.Duration { return 30 * time.Second },
+	}
+
+	opts.Experimental.ReadCompactionRate = 10 << 20 // 20 MiB
+	opts.Experimental.MinDeletionRate = 128 << 20   // 128 MiB
+
+	const numLevels = 7
+	opts.Levels = make([]pebble.LevelOptions, numLevels)
+	for i := 0; i < numLevels; i++ {
+		l := &opts.Levels[i]
+		l.BlockSize = 32 << 10       // 32 KiB
+		l.IndexBlockSize = 256 << 10 // 256 KiB
+		l.FilterPolicy = bloom.FilterPolicy(10)
+		l.FilterType = pebble.TableFilter
+		if i > 0 {
+			l.TargetFileSize = opts.Levels[i-1].TargetFileSize * 2
+		}
+		l.EnsureDefaults()
+	}
+	opts.Levels[numLevels-1].FilterPolicy = nil
+	opts.Cache = pebble.NewCache(1 << 30) // 1 GiB
+
+	path := filepath.Clean(*storePath)
+	store, err := dhstore.NewPebbleDHStore(path, opts)
+	if err != nil {
+		panic(err)
+	}
+	log.Infow("Store opened.", "path", path)
+
+	server, err := dhstore.NewHttpServer(store, *listenAddr)
+	if err != nil {
+		panic(err)
+	}
+	ctx := context.Background()
+	if err := server.Start(ctx); err != nil {
+		panic(err)
+	}
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt)
+	<-c
+	log.Info("Terminating...")
+	if err := server.Shutdown(ctx); err != nil {
+		log.Warnw("Failure occurred while shutting down server.", "err", err)
+	} else {
+		log.Info("Shut down server successfully.")
+	}
+	if err := store.Close(); err != nil {
+		log.Warnw("Failure occurred while closing store.", "err", err)
+	} else {
+		log.Info("Closed store successfully.")
+	}
+}

--- a/errors.go
+++ b/errors.go
@@ -18,11 +18,14 @@ type (
 )
 
 func (e ErrUnsupportedMulticodecCode) Error() string {
-	return fmt.Sprintf("multihash must be of code multihash.DBL_SHA2_256, got: %s", e.code.String())
+	return fmt.Sprintf("multihash must be of code dbl-sha2-256, got: %s", e.code.String())
 }
 
 func (e ErrMultihashDecode) Error() string {
-	return fmt.Sprintf("failed to decode multihash %s: %s", e.mh.B58String(), e.err.Error())
+	if e.err != nil {
+		return fmt.Sprintf("failed to decode multihash %s: %s", e.mh.B58String(), e.err.Error())
+	}
+	return fmt.Sprintf("failed to decode multihash %s", e.mh.B58String())
 }
 
 func (e ErrMultihashDecode) Unwrap() error {

--- a/go.mod
+++ b/go.mod
@@ -5,9 +5,11 @@ go 1.19
 require (
 	github.com/cockroachdb/pebble v0.0.0-20220726144858-a78491c0086f
 	github.com/ipfs/go-log/v2 v2.5.1
+	github.com/mr-tron/base58 v1.2.0
 	github.com/multiformats/go-multicodec v0.7.0
 	github.com/multiformats/go-multihash v0.2.1
 	github.com/multiformats/go-varint v0.0.7
+	github.com/stretchr/testify v1.8.1
 	lukechampine.com/blake3 v1.1.7
 )
 
@@ -19,6 +21,7 @@ require (
 	github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f // indirect
 	github.com/cockroachdb/redact v1.0.8 // indirect
 	github.com/cockroachdb/sentry-go v0.6.1-cockroachdb.2 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/snappy v0.0.3 // indirect
 	github.com/google/go-cmp v0.5.9 // indirect
@@ -28,10 +31,9 @@ require (
 	github.com/kr/text v0.1.0 // indirect
 	github.com/mattn/go-isatty v0.0.16 // indirect
 	github.com/minio/sha256-simd v1.0.0 // indirect
-	github.com/mr-tron/base58 v1.2.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
-	github.com/stretchr/testify v1.8.1 // indirect
 	go.uber.org/atomic v1.10.0 // indirect
 	go.uber.org/goleak v1.1.12 // indirect
 	go.uber.org/multierr v1.8.0 // indirect
@@ -40,4 +42,5 @@ require (
 	golang.org/x/exp v0.0.0-20221205204356-47842c84f3db // indirect
 	golang.org/x/sync v0.1.0 // indirect
 	golang.org/x/sys v0.3.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -358,6 +358,7 @@ google.golang.org/protobuf v1.21.0/go.mod h1:47Nbq4nVaFHyn7ilMalzfO3qCViNmqZ2kzi
 google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/go-playground/assert.v1 v1.2.1/go.mod h1:9RXL0bg/zibRAgZUYszZSwO/z8Y/a8bDuhia5mkpMnE=

--- a/http_api.go
+++ b/http_api.go
@@ -4,10 +4,11 @@ import "github.com/multiformats/go-multihash"
 
 type (
 	MergeIndexRequest struct {
-		Merges []struct {
-			Key   multihash.Multihash `json:"key"`
-			Value EncryptedValueKey   `json:"value"`
-		} `json:"merges"`
+		Merges []Merge `json:"merges"`
+	}
+	Merge struct {
+		Key   multihash.Multihash `json:"key"`
+		Value EncryptedValueKey   `json:"value"`
 	}
 	PutMetadataRequest struct {
 		Key   HashedValueKey    `json:"key"`

--- a/pebble.go
+++ b/pebble.go
@@ -51,10 +51,10 @@ func NewPebbleDHStore(path string, opts *pebble.Options) (*PebbleDHStore, error)
 func (s *PebbleDHStore) MergeIndex(mh multihash.Multihash, evk EncryptedValueKey) error {
 	dmh, err := multihash.Decode(mh)
 	if err != nil {
-		return err
+		return ErrMultihashDecode{err: err, mh: mh}
 	}
 	if multicodec.Code(dmh.Code) != multicodec.DblSha2_256 {
-		return errors.New("multihash key must be of code multicodec.DblSha2_256")
+		return ErrUnsupportedMulticodecCode{code: multicodec.Code(dmh.Code)}
 	}
 	keygen := s.p.leaseSimpleKeyer()
 	defer keygen.Close()

--- a/pebble_test.go
+++ b/pebble_test.go
@@ -1,0 +1,46 @@
+package dhstore_test
+
+import (
+	"testing"
+
+	"github.com/ipni/dhstore"
+	"github.com/multiformats/go-multihash"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPebbleDHStore_MultihashCheck(t *testing.T) {
+	someValue := dhstore.EncryptedValueKey("fish")
+	notDblMh, err := multihash.Sum([]byte("fish"), multihash.SHA2_256, -1)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name        string
+		givenMh     multihash.Multihash
+		wantErrType error
+	}{
+		{
+			name:        "invalid",
+			givenMh:     multihash.Multihash("lobster"),
+			wantErrType: dhstore.ErrMultihashDecode{},
+		},
+		{
+			name:        "not dbl_sha2_256",
+			givenMh:     notDblMh,
+			wantErrType: dhstore.ErrUnsupportedMulticodecCode{},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			subject, err := dhstore.NewPebbleDHStore(t.TempDir(), nil)
+			require.NoError(t, err)
+			err = subject.MergeIndex(test.givenMh, someValue)
+			require.Error(t, err)
+			require.IsType(t, test.wantErrType, err)
+
+			gotV, err := subject.Lookup(test.givenMh)
+			require.Error(t, err)
+			require.IsType(t, test.wantErrType, err)
+			require.Nil(t, gotV)
+		})
+	}
+}


### PR DESCRIPTION
Implemnet a simple CLI command for `dhstore` which creates a new pebble backed store and starts up the HTTP server with endpoints to allow remote PUT GET operations.

Refine error handling in pebble implementation so that HTTP server can return appropriate HTTP status code.

Add CI jobs that build and publish images to two container registries: ghcr.io as a public registry for anyone who might be interested, and an ECR private registry used for service deployment.