### PR TITLE
Rename response keys for consistency

### DIFF
--- a/http_api.go
+++ b/http_api.go
@@ -18,8 +18,8 @@ type (
 		EncryptedMultihashResults []EncryptedMultihashResult `json:"EncryptedMultihashResult"`
 	}
 	EncryptedMultihashResult struct {
-		Multihash                multihash.Multihash `json:"Multihash"`
-		EncryptedProviderResults []EncryptedValueKey `json:"EncryptedProviderResults"`
+		Multihash          multihash.Multihash `json:"Multihash"`
+		EncryptedValueKeys []EncryptedValueKey `json:"EncryptedValueKeys"`
 	}
 	GetMetadataResponse struct {
 		EncryptedMetadata EncryptedMetadata `json:"EncryptedMetadata"`

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -66,7 +66,7 @@ paths:
                         Multihash:
                           type: string
                           description: base58 string representation of queried multihash
-                        EncryptedProviderResults:
+                        EncryptedValueKeys:
                           type: array
                           items:
                             type: string

--- a/server.go
+++ b/server.go
@@ -123,8 +123,8 @@ func (s *Server) handleGetMh(w http.ResponseWriter, r *http.Request) {
 	lr := LookupResponse{
 		EncryptedMultihashResults: []EncryptedMultihashResult{
 			{
-				Multihash:                mh,
-				EncryptedProviderResults: evks,
+				Multihash:          mh,
+				EncryptedValueKeys: evks,
 			},
 		},
 	}


### PR DESCRIPTION
Use consistent terminology in lookup response. This should also avoid JSON decoding and combining efforts in indexstar.