### PR TITLE
Implement a merger that removes duplicate records on merge

### DIFF
--- a/pebble_merger.go
+++ b/pebble_merger.go
@@ -1,58 +1,126 @@
 package dhstore
 
 import (
+	"bytes"
 	"io"
 
 	"github.com/cockroachdb/pebble"
 )
 
-const deletableDefaultMergerName = "dhstore.v1.deletable_default_merger"
+const valueKeysMergerName = "dhstore.v1.valueKeysMerger"
 
 var (
-	_ pebble.ValueMerger          = (*deletableDefaultMerger)(nil)
-	_ pebble.DeletableValueMerger = (*deletableDefaultMerger)(nil)
+	_ pebble.ValueMerger          = (*valueKeysValueMerger)(nil)
+	_ pebble.DeletableValueMerger = (*valueKeysValueMerger)(nil)
 )
 
-type deletableDefaultMerger struct {
-	def pebble.ValueMerger
+type valueKeysValueMerger struct {
+	merges             []EncryptedValueKey
+	reverse            bool
+	marshalledSizeHint int // Used as a hint to grow the buffer size during marshalling.
+	s                  *PebbleDHStore
 }
 
-func newDeletableDefaultMerger() *pebble.Merger {
+func (s *PebbleDHStore) newValueKeysMerger() *pebble.Merger {
 	return &pebble.Merger{
 		Merge: func(k, value []byte) (pebble.ValueMerger, error) {
 			// Fall back on default merger if the key is not of type multihash, i.e. the only key
 			// type that corresponds to value-keys.
 			switch keyPrefix(k[0]) {
 			case multihashKeyPrefix:
-				merge, err := pebble.DefaultMerger.Merge(k, value)
-				if err != nil {
-					return nil, err
-				}
-				v := &deletableDefaultMerger{
-					def: merge,
-				}
-				return v, nil
+				v := &valueKeysValueMerger{s: s}
+				return v, v.MergeNewer(value)
 			default:
 				return pebble.DefaultMerger.Merge(k, value)
 			}
 		},
-		Name: deletableDefaultMergerName,
+		Name: valueKeysMergerName,
 	}
 }
 
-func (v *deletableDefaultMerger) MergeNewer(value []byte) error {
-	return v.def.MergeNewer(value)
+func (v *valueKeysValueMerger) MergeNewer(value []byte) error {
+	if len(value) == 0 {
+		return nil
+	}
+
+	evks, err := v.s.unmarshalEncryptedIndexKeys(value)
+	if err != nil {
+		return err
+	}
+
+	v.merges = maybeGrow(v.merges, len(evks))
+
+	if len(v.merges) == 0 {
+		// Optimise for the case where there are no merges.
+		v.merges = append(v.merges, evks...)
+		v.marshalledSizeHint += len(value)
+	} else {
+		for _, evk := range evks {
+			if !v.exists(evk) {
+				v.merges = append(v.merges, evk)
+				v.marshalledSizeHint += len(evk)
+			}
+		}
+	}
+
+	return nil
 }
 
-func (v *deletableDefaultMerger) MergeOlder(value []byte) error {
-	return v.def.MergeOlder(value)
+func (v *valueKeysValueMerger) MergeOlder(value []byte) error {
+	v.reverse = true
+	return v.MergeNewer(value)
 }
 
-func (v *deletableDefaultMerger) Finish(includesBase bool) ([]byte, io.Closer, error) {
-	return v.def.Finish(includesBase)
+func (v *valueKeysValueMerger) Finish(_ bool) ([]byte, io.Closer, error) {
+	if len(v.merges) == 0 {
+		return nil, nil, nil
+	}
+	if v.reverse {
+		for one, other := 0, len(v.merges)-1; one < other; one, other = one+1, other-1 {
+			v.merges[one], v.merges[other] = v.merges[other], v.merges[one]
+		}
+	}
+	return v.marshalMerges()
 }
 
-func (v *deletableDefaultMerger) DeletableFinish(includesBase bool) ([]byte, bool, io.Closer, error) {
+func (v *valueKeysValueMerger) DeletableFinish(includesBase bool) ([]byte, bool, io.Closer, error) {
 	b, c, err := v.Finish(includesBase)
 	return b, len(b) == 0, c, err
+}
+
+// exists checks whether the given value is already present, either pending merge or deletion.
+func (v *valueKeysValueMerger) exists(value []byte) bool {
+	for _, x := range v.merges {
+		if bytes.Equal(x, value) {
+			return true
+		}
+	}
+	return false
+}
+
+func (v *valueKeysValueMerger) marshalMerges() ([]byte, io.Closer, error) {
+	buf := v.s.p.leaseSectionBuff()
+	// Encrypted value keys are marshalled as varint + their byte value.
+	// Optimistically, add the length of merges to the size hint to compensate for the additional
+	// varints that'd be added to the beginning.
+	buf.maybeGrow(v.marshalledSizeHint + len(v.merges))
+	for _, merge := range v.merges {
+		buf.writeSection(merge)
+	}
+	return buf.buf, buf, nil
+}
+
+// maybeGrow grows the capacity of the given slice if necessary, such that it can fit n more
+// elements and returns the resulting slice.
+func maybeGrow(s []EncryptedValueKey, n int) []EncryptedValueKey {
+	const growthFactor = 2
+	l := len(s)
+	switch {
+	case n <= cap(s)-l:
+		return s
+	case l == 0:
+		return make([]EncryptedValueKey, 0, n*growthFactor)
+	default:
+		return append(make([]EncryptedValueKey, 0, (l+n)*growthFactor), s...)
+	}
 }

--- a/pebble_merger_test.go
+++ b/pebble_merger_test.go
@@ -1,0 +1,73 @@
+package dhstore
+
+import (
+	"testing"
+
+	"github.com/multiformats/go-multihash"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValueKeysMerger_IsAssociative(t *testing.T) {
+	store, err := NewPebbleDHStore(t.TempDir(), nil)
+	require.NoError(t, err)
+	defer store.Close()
+
+	subject := store.newValueKeysMerger()
+
+	bk := store.p.leaseSimpleKeyer()
+	k, err := bk.multihashKey(multihash.Multihash("fish"))
+	require.NoError(t, err)
+
+	a := []byte{0x1, 0x65}
+	b := []byte{0x1, 0x66}
+	c := []byte{0x1, 0x67}
+
+	oneMerge, err := subject.Merge(k.buf, a)
+	require.NoError(t, err)
+	require.NoError(t, oneMerge.MergeOlder(b))
+	require.NoError(t, oneMerge.MergeOlder(c))
+	gotOne, _, err := oneMerge.Finish(false)
+	require.NoError(t, err)
+
+	anotherMerge, err := subject.Merge(k.buf, c)
+	require.NoError(t, err)
+
+	require.NoError(t, anotherMerge.MergeNewer(b))
+	require.NoError(t, anotherMerge.MergeNewer(a))
+	gotAnother, _, err := anotherMerge.Finish(false)
+	require.NoError(t, err)
+	require.Equal(t, gotOne, gotAnother, "merge is not associative. %v != %v", gotOne, gotAnother)
+}
+
+func TestValueKeysMerger_RemovesDuplicateValues(t *testing.T) {
+	store, err := NewPebbleDHStore(t.TempDir(), nil)
+	require.NoError(t, err)
+	defer store.Close()
+
+	subject := store.newValueKeysMerger()
+
+	bk := store.p.leaseSimpleKeyer()
+	k, err := bk.multihashKey(multihash.Multihash("fish"))
+	require.NoError(t, err)
+
+	a := []byte{0x1, 0x65}
+	b := []byte{0x1, 0x66}
+	c := []byte{0x1, 0x67}
+	wantMerge := append(a, append(b, c...)...)
+
+	merger, err := subject.Merge(k.buf, a)
+	require.NoError(t, err)
+	require.NoError(t, merger.MergeNewer(b))
+	require.NoError(t, merger.MergeNewer(c))
+	require.NoError(t, merger.MergeNewer(c))
+	require.NoError(t, merger.MergeNewer(a))
+	require.NoError(t, merger.MergeNewer(c))
+	require.NoError(t, merger.MergeNewer(b))
+	require.NoError(t, merger.MergeNewer(b))
+	require.NoError(t, merger.MergeNewer(a))
+	require.NoError(t, merger.MergeNewer(a))
+	gotMerged, _, err := merger.Finish(false)
+	require.NoError(t, err)
+	require.Equal(t, wantMerge, gotMerged)
+
+}


### PR DESCRIPTION
Change the merger to remove duplicate encrypted value keys on merge. This reduces redundant storage of duplicate values while avoiding the need to read the entire record on put just to remove duplicates.