### PR TITLE
Fix missing `s` in lookup JSON response and add more tests

### DIFF
--- a/http_api.go
+++ b/http_api.go
@@ -15,7 +15,7 @@ type (
 		Value EncryptedMetadata `json:"value"`
 	}
 	LookupResponse struct {
-		EncryptedMultihashResults []EncryptedMultihashResult `json:"EncryptedMultihashResult"`
+		EncryptedMultihashResults []EncryptedMultihashResult `json:"EncryptedMultihashResults"`
 	}
 	EncryptedMultihashResult struct {
 		Multihash          multihash.Multihash `json:"Multihash"`


### PR DESCRIPTION
Fix a typo in lookup JSON response and add tests that assert the happy path works as expected when looking up an existing entry.