### PR TITLE
Define K8S deployment manifests

### DIFF
--- a/deploy/kubernetes/deployment.yaml
+++ b/deploy/kubernetes/deployment.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dhstore
+spec:
+  replicas: 1
+  strategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: dhstore
+  template:
+    metadata:
+      labels:
+        app: dhstore
+    spec:
+      containers:
+        - name: dhstore
+          image: dhstore
+          envFrom:
+            - configMapRef:
+                name: dhstore-env-vars
+          ports:
+            - containerPort: 40080
+              name: http
+          readinessProbe:
+            httpGet:
+              port: http
+              path: /ready
+            initialDelaySeconds: 3
+            failureThreshold: 3
+            successThreshold: 1
+            timeoutSeconds: 5
+            periodSeconds: 10

--- a/deploy/kubernetes/kustomization.yaml
+++ b/deploy/kubernetes/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - deployment.yaml
+  - service.yaml
+  - pdb.yaml
+
+transformers:
+  - labels.yaml
+
+configMapGenerator:
+  - name: dhstore-env-vars
+    behavior: create
+    literals:
+      - GOLOG_LOG_LEVEL=INFO
+      - GOLOG_LOG_FMT=json

--- a/deploy/kubernetes/labels.yaml
+++ b/deploy/kubernetes/labels.yaml
@@ -1,0 +1,10 @@
+apiVersion: builtin
+kind: LabelTransformer
+metadata:
+  name: labels
+labels:
+  app.kubernetes.io/part-of: ipni
+  app.kubernetes.io/managed-by: kustomization
+fieldSpecs:
+  - path: metadata/labels
+    create: true

--- a/deploy/kubernetes/pdb.yaml
+++ b/deploy/kubernetes/pdb.yaml
@@ -1,0 +1,11 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: dhstore
+  labels:
+    app: dhstore
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: dhstore

--- a/deploy/kubernetes/service.yaml
+++ b/deploy/kubernetes/service.yaml
@@ -1,0 +1,15 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: dhstore
+  labels:
+    app: dhstore
+spec:
+  ports:
+    - name: http
+      port: 40080
+      targetPort: http
+  selector:
+    app: dhstore
+  type: ClusterIP
+  clusterIP: None

--- a/server.go
+++ b/server.go
@@ -41,6 +41,7 @@ func (s *Server) serveMux() *http.ServeMux {
 	mux.HandleFunc("/multihash", s.handleMh)
 	mux.HandleFunc("/multihash/", s.handleMhSubtree)
 	mux.HandleFunc("/metadata/", s.handleMetadata)
+	mux.HandleFunc("/ready", s.handleReady)
 	mux.HandleFunc("/", s.handleCatchAll)
 	return mux
 }
@@ -195,6 +196,16 @@ func (s *Server) handleGetMetadata(w http.ResponseWriter, r *http.Request) {
 	}
 	if err := json.NewEncoder(w).Encode(gmr); err != nil {
 		log.Errorw("Failed to write get metadata response", "err", err, "key", sk)
+	}
+}
+
+func (s *Server) handleReady(w http.ResponseWriter, r *http.Request) {
+	discardBody(r)
+	switch r.Method {
+	case http.MethodGet:
+		w.WriteHeader(http.StatusOK)
+	default:
+		http.Error(w, "", http.StatusNotFound)
 	}
 }
 


### PR DESCRIPTION
Define reusable YAMLs that allow `dhstore` to be deployed onto a K8S cluster. As part of definitions, introduce an endpoint on the server to check for readiness.