### PR TITLE
Fix GET `/metadata/<key>` HTTP API

### DIFF
--- a/server.go
+++ b/server.go
@@ -41,6 +41,7 @@ func (s *Server) serveMux() *http.ServeMux {
 	mux.HandleFunc("/multihash", s.handleMh)
 	mux.HandleFunc("/multihash/", s.handleMhSubtree)
 	mux.HandleFunc("/metadata", s.handleMetadata)
+	mux.HandleFunc("/metadata/", s.handleMetadataSubtree)
 	mux.HandleFunc("/ready", s.handleReady)
 	mux.HandleFunc("/", s.handleCatchAll)
 	return mux
@@ -153,8 +154,6 @@ func (s *Server) handleMetadata(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case http.MethodPut:
 		s.handlePutMetadata(w, r)
-	case http.MethodGet:
-		s.handleGetMetadata(w, r)
 	default:
 		discardBody(r)
 		http.Error(w, "", http.StatusNotFound)
@@ -174,6 +173,16 @@ func (s *Server) handlePutMetadata(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.WriteHeader(http.StatusAccepted)
+}
+
+func (s *Server) handleMetadataSubtree(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		s.handleGetMetadata(w, r)
+	default:
+		discardBody(r)
+		http.Error(w, "", http.StatusNotFound)
+	}
 }
 
 func (s *Server) handleGetMetadata(w http.ResponseWriter, r *http.Request) {

--- a/server_test.go
+++ b/server_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/ipni/dhstore"
+	"github.com/mr-tron/base58"
 	"github.com/multiformats/go-multihash"
 	"github.com/stretchr/testify/require"
 )
@@ -131,6 +132,28 @@ func TestNewHttpServeMux(t *testing.T) {
 			onTarget:     "/multihash/2wvdp9y1J63yDvaPawP4kUjXezRLcu9x9u2DAB154dwai82",
 			expectStatus: http.StatusOK,
 			expectBody:   `{"EncryptedMultihashResults": [{ "Multihash": "ViAJKqT0hRtxENbtjWwvnRogQknxUnhswNrose3ZjEP8Iw==", "EncryptedValueKeys": ["ZmlzaA=="] }]}`,
+			expectJSON:   true,
+		},
+		{
+			name:         "PUT /metadata with valid key value is 202",
+			onMethod:     http.MethodPut,
+			onBody:       `{"key": "ZmlzaA==", "value": "ZmlzaA==" }`,
+			onTarget:     "/metadata",
+			expectStatus: http.StatusAccepted,
+		},
+		{
+			name: "GET /metadata with existing key is 200",
+			onStore: func(t *testing.T, store dhstore.DHStore) {
+				key := []byte("fish")
+				err := store.PutMetadata(key, []byte("lobster"))
+				require.NoError(t, err)
+				t.Logf("metadata with key %s stored", base58.Encode(key))
+			},
+			onMethod:     http.MethodGet,
+			onBody:       `{"key": "ZmlzaA==", "value": "ZmlzaA==" }`,
+			onTarget:     "/metadata/3cqA6K",
+			expectStatus: http.StatusOK,
+			expectBody:   `{"EncryptedMetadata":"bG9ic3Rlcg=="}`,
 			expectJSON:   true,
 		},
 	}


### PR DESCRIPTION
Refine changes to routing to handle `/metadata` subtree URI correctly.

Add tests for `PUT` and `GET` metadata.