### PR TITLE
Use `ms` as unit for milliseconds

### DIFF
--- a/cmd/dhstore/main.go
+++ b/cmd/dhstore/main.go
@@ -103,7 +103,7 @@ func main() {
 	if err := m.Shutdown(ctx); err != nil {
 		log.Warnw("Failure occurred while shutting down metrics server.", "err", err)
 	} else {
-		log.Info("Shut down metrcis server successfully.")
+		log.Info("Shut down metrics server successfully.")
 	}
 
 	if err := store.Close(); err != nil {

--- a/deploy/kubernetes/deployment.yaml
+++ b/deploy/kubernetes/deployment.yaml
@@ -25,6 +25,8 @@ spec:
           ports:
             - containerPort: 40080
               name: http
+            - containerPort: 40081
+              name: metrics
           readinessProbe:
             httpGet:
               port: http

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -12,6 +12,7 @@ import (
 	"go.opentelemetry.io/otel/exporters/prometheus"
 	"go.opentelemetry.io/otel/metric/instrument"
 	"go.opentelemetry.io/otel/metric/instrument/syncint64"
+	"go.opentelemetry.io/otel/metric/unit"
 	"go.opentelemetry.io/otel/sdk/metric"
 )
 
@@ -40,7 +41,7 @@ func New(metricsAddr string) (*Metrics, error) {
 	meter := provider.Meter("ipni/dhstore")
 
 	if m.httpLatency, err = meter.SyncInt64().Histogram("ipni/dhstore/http_latency",
-		instrument.WithUnit("milliseconds"),
+		instrument.WithUnit(unit.Milliseconds),
 		instrument.WithDescription("Latency of DHStore HTTP API")); err != nil {
 		return nil, err
 	}

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -21,17 +21,13 @@ var (
 )
 
 type Metrics struct {
-	exporter *prometheus.Exporter
-
+	exporter    *prometheus.Exporter
 	httpLatency syncint64.Histogram
-
-	s *http.Server
+	s           *http.Server
 }
 
 func New(metricsAddr string) (*Metrics, error) {
-
 	var m Metrics
-
 	var err error
 	if m.exporter, err = prometheus.New(prometheus.WithoutUnits()); err != nil {
 		return nil, err


### PR DESCRIPTION
Use the already defined unit for milliseconds with string value `ms`.