### PR TITLE
Implement streaming NDJSON response for encrypted lookups

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -2,6 +2,7 @@ package dhstore
 
 import (
 	"fmt"
+	"net/http"
 
 	"github.com/multiformats/go-multicodec"
 	"github.com/multiformats/go-multihash"
@@ -14,6 +15,11 @@ type (
 	ErrMultihashDecode struct {
 		mh  multihash.Multihash
 		err error
+	}
+
+	errHttpResponse struct {
+		message string
+		status  int
 	}
 )
 
@@ -30,4 +36,12 @@ func (e ErrMultihashDecode) Error() string {
 
 func (e ErrMultihashDecode) Unwrap() error {
 	return e.err
+}
+
+func (e errHttpResponse) Error() string {
+	return e.message
+}
+
+func (e errHttpResponse) WriteTo(w http.ResponseWriter) {
+	http.Error(w, e.message, e.status)
 }

--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/kr/pretty v0.2.1 // indirect
 	github.com/kr/text v0.1.0 // indirect
 	github.com/mattn/go-isatty v0.0.16 // indirect
-	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
+	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
 	github.com/minio/sha256-simd v1.0.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
@@ -52,7 +52,7 @@ require (
 	go.uber.org/goleak v1.1.12 // indirect
 	go.uber.org/multierr v1.8.0 // indirect
 	go.uber.org/zap v1.24.0 // indirect
-	golang.org/x/crypto v0.3.0 // indirect
+	golang.org/x/crypto v0.4.0 // indirect
 	golang.org/x/exp v0.0.0-20221205204356-47842c84f3db // indirect
 	golang.org/x/sync v0.1.0 // indirect
 	golang.org/x/sys v0.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -262,8 +262,9 @@ github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27k
 github.com/mattn/go-isatty v0.0.16 h1:bq3VjFmv/sOjHtdEhmkEV4x1AJtvUvOJ2PFAZ5+peKQ=
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/goveralls v0.0.2/go.mod h1:8d1ZMHsd7fW6IRPKQh46F2WRpyib5/X4FOpevwGNQEw=
-github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
+github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zkfA9PSy5pEvNWRP0ET0TIVo=
+github.com/matttproud/golang_protobuf_extensions v1.0.4/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
 github.com/mediocregopher/mediocre-go-lib v0.0.0-20181029021733-cb65787f37ed/go.mod h1:dSsfyI2zABAdhcbvkXqgxOxrCsbYeHCPgrZkku60dSg=
 github.com/mediocregopher/radix/v3 v3.3.0/go.mod h1:EmfVyvspXz1uZEyPBMyGK+kjWiKQGvsUt6O3Pj+LDCQ=
 github.com/microcosm-cc/bluemonday v1.0.2/go.mod h1:iVP4YcDBq+n/5fb23BhYFvIMq/leAFZyRl6bYmGDlGc=
@@ -420,8 +421,8 @@ golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/crypto v0.3.0 h1:a06MkbcxBrEFc0w0QIZWXrH/9cCX6KJyWbBOIwAn+7A=
-golang.org/x/crypto v0.3.0/go.mod h1:hebNnKkNXi2UzZN1eVRvBB7co0a+JxK6XbPiWVs/3J4=
+golang.org/x/crypto v0.4.0 h1:UVQgzMY87xqpKNgb+kDsll2Igd33HszWHFLmpaRMq/8=
+golang.org/x/crypto v0.4.0/go.mod h1:3quD/ATkf6oY+rnes5c3ExXTbLc8mueNue5/DoinL80=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=

--- a/http_api.go
+++ b/http_api.go
@@ -24,4 +24,7 @@ type (
 	GetMetadataResponse struct {
 		EncryptedMetadata EncryptedMetadata `json:"EncryptedMetadata"`
 	}
+	EncryptedValueKeyResult struct {
+		EncryptedValueKey EncryptedValueKey `json:"EncryptedValueKey"`
+	}
 )

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -71,6 +71,22 @@ paths:
                           items:
                             type: string
                             description: base64 encoded encrypted index value keys.
+              example: |
+                {"EncryptedMultihashResults": [{ "Multihash": "ViAJKqT0hRtxENbtjWwvnRogQknxUnhswNrose3ZjEP8Iw==", "EncryptedValueKeys": ["ZmlzaA==", "bG9ic3Rlcg==", "dW5kYWRhc2Vh"] }]}
+            'application/x-ndjson':
+              schema:
+                type: object
+                properties:
+                  EncryptedValueKey:
+                    type: string
+                    description: base64 encoded encrypted index value keys.
+              example: |
+                {"EncryptedValueKey":"ZmlzaA=="}
+                
+                {"EncryptedValueKey":"bG9ic3Rlcg=="}
+                
+                {"EncryptedValueKey":"dW5kYWRhc2Vh"}
+                
         '400':
           description: The given request is not valid.
           content:

--- a/pebble.go
+++ b/pebble.go
@@ -11,7 +11,7 @@ import (
 )
 
 var (
-	log = logging.Logger("store/pebble")
+	logger = logging.Logger("store/pebble")
 
 	_ DHStore = (*PebbleDHStore)(nil)
 )
@@ -106,7 +106,7 @@ func (s *PebbleDHStore) Lookup(mh multihash.Multihash) ([]EncryptedValueKey, err
 		if errors.Is(err, pebble.ErrNotFound) {
 			return nil, nil
 		}
-		log.Debugw("failed to find multihash", "key", mh.B58String(), "err", err)
+		logger.Debugw("failed to find multihash", "key", mh.B58String(), "err", err)
 		return nil, err
 	}
 	defer vkbClose.Close()

--- a/response_writer.go
+++ b/response_writer.go
@@ -1,0 +1,21 @@
+package dhstore
+
+import (
+	"io"
+	"net/http"
+
+	"github.com/multiformats/go-multihash"
+)
+
+type (
+	selectiveResponseWriter interface {
+		http.ResponseWriter
+		Accept(r *http.Request) error
+	}
+	lookupResponseWriter interface {
+		io.Closer
+		selectiveResponseWriter
+		Key() multihash.Multihash
+		WriteEncryptedValueKey(EncryptedValueKey) error
+	}
+)

--- a/response_writer_ipni.go
+++ b/response_writer_ipni.go
@@ -1,0 +1,79 @@
+package dhstore
+
+import (
+	"net/http"
+	"path"
+	"strings"
+
+	"github.com/multiformats/go-multihash"
+)
+
+var (
+	_ lookupResponseWriter = (*ipniLookupResponseWriter)(nil)
+
+	newline = []byte("\n")
+)
+
+type ipniLookupResponseWriter struct {
+	jsonResponseWriter
+	result EncryptedMultihashResult
+	count  int
+}
+
+func newIPNILookupResponseWriter(w http.ResponseWriter, preferJson bool) lookupResponseWriter {
+	return &ipniLookupResponseWriter{
+		jsonResponseWriter: newJsonResponseWriter(w, preferJson),
+	}
+}
+
+func (i *ipniLookupResponseWriter) Accept(r *http.Request) error {
+	if err := i.jsonResponseWriter.Accept(r); err != nil {
+		return err
+	}
+	smh := strings.TrimPrefix(path.Base(r.URL.Path), "multihash/")
+	var err error
+	i.result.Multihash, err = multihash.FromB58String(smh)
+	if err != nil {
+		return errHttpResponse{message: err.Error(), status: http.StatusBadRequest}
+	}
+	return nil
+}
+
+func (i *ipniLookupResponseWriter) Key() multihash.Multihash {
+	return i.result.Multihash
+}
+
+func (i *ipniLookupResponseWriter) WriteEncryptedValueKey(evk EncryptedValueKey) error {
+	if i.nd {
+		if err := i.encoder.Encode(EncryptedValueKeyResult{
+			EncryptedValueKey: evk,
+		}); err != nil {
+			logger.Errorw("Failed to encode ndjson response", "err", err)
+			return err
+		}
+		if _, err := i.w.Write(newline); err != nil {
+			logger.Errorw("Failed to encode ndjson response", "err", err)
+			return err
+		}
+		if i.f != nil {
+			i.f.Flush()
+		}
+	} else {
+		i.result.EncryptedValueKeys = append(i.result.EncryptedValueKeys, evk)
+	}
+	i.count++
+	return nil
+}
+
+func (i *ipniLookupResponseWriter) Close() error {
+	if i.count == 0 {
+		return errHttpResponse{status: http.StatusNotFound}
+	}
+	logger.Debugw("Finished writing ipni results", "count", i.count)
+	if i.nd {
+		return nil
+	}
+	return i.encoder.Encode(LookupResponse{
+		EncryptedMultihashResults: []EncryptedMultihashResult{i.result},
+	})
+}

--- a/response_writer_json.go
+++ b/response_writer_json.go
@@ -1,0 +1,97 @@
+package dhstore
+
+import (
+	"encoding/json"
+	"fmt"
+	"mime"
+	"net/http"
+	"strings"
+)
+
+const (
+	mediaTypeNDJson = "application/x-ndjson"
+	mediaTypeJson   = "application/json"
+	mediaTypeAny    = "*/*"
+)
+
+var (
+	_ selectiveResponseWriter = (*jsonResponseWriter)(nil)
+	_ http.ResponseWriter     = (*jsonResponseWriter)(nil)
+)
+
+type jsonResponseWriter struct {
+	w          http.ResponseWriter
+	f          http.Flusher
+	encoder    *json.Encoder
+	nd         bool
+	preferJson bool
+}
+
+func newJsonResponseWriter(w http.ResponseWriter, preferJson bool) jsonResponseWriter {
+	return jsonResponseWriter{
+		w:          w,
+		encoder:    json.NewEncoder(w),
+		preferJson: preferJson,
+	}
+}
+
+func (i *jsonResponseWriter) Accept(r *http.Request) error {
+	accepts := r.Header.Values("Accept")
+	var okJson bool
+	for _, accept := range accepts {
+		amts := strings.Split(accept, ",")
+		for _, amt := range amts {
+			mt, _, err := mime.ParseMediaType(amt)
+			if err != nil {
+				logger.Debugw("Failed to check accepted response media type", "err", err)
+				return errHttpResponse{message: "invalid Accept header", status: http.StatusBadRequest}
+			}
+			switch mt {
+			case mediaTypeNDJson:
+				i.nd = true
+			case mediaTypeJson:
+				okJson = true
+			case mediaTypeAny:
+				i.nd = !i.preferJson
+				okJson = true
+			}
+			if i.nd && okJson {
+				break
+			}
+		}
+	}
+
+	switch {
+	case len(accepts) == 0:
+		// If there is no `Accept` header and JSON is preferred then be forgiving and fall back
+		// onto JSON media type. Otherwise, strictly require `Accept` header.
+		if !i.preferJson {
+			return errHttpResponse{message: "Accept header must be specified", status: http.StatusBadRequest}
+		}
+	case !okJson && !i.nd:
+		return errHttpResponse{message: fmt.Sprintf("media type not supported: %s", accepts), status: http.StatusBadRequest}
+	}
+
+	i.f, _ = i.w.(http.Flusher)
+
+	if i.nd {
+		i.w.Header().Set("Content-Type", mediaTypeNDJson)
+		i.w.Header().Set("Connection", "Keep-Alive")
+		i.w.Header().Set("X-Content-Type-Options", "nosniff")
+	} else {
+		i.w.Header().Set("Content-Type", mediaTypeJson)
+	}
+	return nil
+}
+
+func (i *jsonResponseWriter) Header() http.Header {
+	return i.w.Header()
+}
+
+func (i *jsonResponseWriter) Write(b []byte) (int, error) {
+	return i.w.Write(b)
+}
+
+func (i *jsonResponseWriter) WriteHeader(code int) {
+	i.w.WriteHeader(code)
+}


### PR DESCRIPTION
Implement the ability to handle streaming response to multihash lookups. This capability will then allow us to enable translation to streaming responses by default on indexstar, since `dhstore` is the only backend remaining that does not support it.