### PR TITLE
Reduce pebble block cache size

### DIFF
--- a/cmd/dhstore/main.go
+++ b/cmd/dhstore/main.go
@@ -64,7 +64,7 @@ func main() {
 		l.EnsureDefaults()
 	}
 	opts.Levels[numLevels-1].FilterPolicy = nil
-	opts.Cache = pebble.NewCache(1 << 30) // 1 GiB
+	opts.Cache = pebble.NewCache(1 << 29) // 1/2 GiB
 
 	path := filepath.Clean(*storePath)
 	store, err := dhstore.NewPebbleDHStore(path, opts)

--- a/cmd/dhstore/main.go
+++ b/cmd/dhstore/main.go
@@ -64,7 +64,7 @@ func main() {
 		l.EnsureDefaults()
 	}
 	opts.Levels[numLevels-1].FilterPolicy = nil
-	opts.Cache = pebble.NewCache(1 << 29) // 1/2 GiB
+	opts.Cache = pebble.NewCache(512 << 20) // 512 MiB
 
 	path := filepath.Clean(*storePath)
 	store, err := dhstore.NewPebbleDHStore(path, opts)


### PR DESCRIPTION
From the recently observed behaviour in production, high write latencies (>30s) are correlated with block cache compressions that are greater than approx 600MB. Smaller compressions (<500MB) will result into smoother write profile. 


Block cache size
![image](https://user-images.githubusercontent.com/31857042/226325128-e5191216-4524-4127-96e3-f99bbfda20d2.png)

Write timeouts (>30s latency)
![image](https://user-images.githubusercontent.com/31857042/226325328-f9e16a48-be9d-4baa-9d4b-4fc2cfd81477.png)


