### PR TITLE
Change `DHStore` interface to merge index in batches

### DIFF
--- a/bench/bench_test.go
+++ b/bench/bench_test.go
@@ -169,10 +169,12 @@ func getMultihashes(b *testing.B, mhs []multihash.Multihash, store dhstore.DHSto
 }
 
 func putMultihashes(b *testing.B, mhs []multihash.Multihash, vks [][]byte, store dhstore.DHStore) {
+	indexes := make([]dhstore.Index, 0, len(mhs))
 	for i, mh := range mhs {
-		err := store.MergeIndex(mh, vks[i])
-		require.NoError(b, err)
+		indexes = append(indexes, dhstore.Index{Key: mh, Value: vks[i]})
 	}
+	err := store.MergeIndexes(indexes)
+	require.NoError(b, err)
 }
 
 func putMetadatas(b *testing.B, hvks, metadatas [][]byte, store dhstore.DHStore) {

--- a/dhstore.go
+++ b/dhstore.go
@@ -10,9 +10,13 @@ type (
 	EncryptedValueKey []byte
 	EncryptedMetadata []byte
 	HashedValueKey    []byte
-	DHStore           interface {
+	Index             struct {
+		Key   multihash.Multihash `json:"key"`
+		Value EncryptedValueKey   `json:"value"`
+	}
+	DHStore interface {
 		io.Closer
-		MergeIndex(multihash.Multihash, EncryptedValueKey) error
+		MergeIndexes([]Index) error
 		PutMetadata(HashedValueKey, EncryptedMetadata) error
 		Lookup(multihash.Multihash) ([]EncryptedValueKey, error)
 		GetMetadata(HashedValueKey) (EncryptedMetadata, error)

--- a/pebble/pebble_test.go
+++ b/pebble/pebble_test.go
@@ -36,7 +36,7 @@ func TestPebbleDHStore_MultihashCheck(t *testing.T) {
 			require.NoError(t, err)
 			defer subject.Close()
 
-			err = subject.MergeIndex(test.givenMh, someValue)
+			err = subject.MergeIndexes([]dhstore.Index{{Key: test.givenMh, Value: someValue}})
 			require.Error(t, err)
 			require.IsType(t, test.wantErrType, err)
 

--- a/server/model.go
+++ b/server/model.go
@@ -7,11 +7,7 @@ import (
 
 type (
 	MergeIndexRequest struct {
-		Merges []Merge `json:"merges"`
-	}
-	Merge struct {
-		Key   multihash.Multihash       `json:"key"`
-		Value dhstore.EncryptedValueKey `json:"value"`
+		Merges []dhstore.Index `json:"merges"`
 	}
 	PutMetadataRequest struct {
 		Key   dhstore.HashedValueKey    `json:"key"`

--- a/server/server.go
+++ b/server/server.go
@@ -132,14 +132,9 @@ func (s *Server) handlePutMhs(w http.ResponseWriter, r *http.Request) {
 	if len(mir.Merges) == 0 {
 		http.Error(w, "at least one merge must be specified", http.StatusBadRequest)
 	}
-
-	// TODO: Use pebble batch which will require interface changes.
-	//       But no big deal for now because every write to pebble is by NoSync.
-	for _, merge := range mir.Merges {
-		if err := s.dhs.MergeIndex(merge.Key, merge.Value); err != nil {
-			s.handleError(w, err)
-			return
-		}
+	if err := s.dhs.MergeIndexes(mir.Merges); err != nil {
+		s.handleError(w, err)
+		return
 	}
 	logger.Infow("Finished putting multihashes", "count", len(mir.Merges))
 	if len(mir.Merges) != 0 {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -130,7 +130,7 @@ func TestNewHttpServeMux(t *testing.T) {
 			onStore: func(t *testing.T, store dhstore.DHStore) {
 				mh, err := multihash.FromB58String("2wvdp9y1J63yDvaPawP4kUjXezRLcu9x9u2DAB154dwai82")
 				require.NoError(t, err)
-				require.NoError(t, store.MergeIndex(mh, []byte("fish")))
+				require.NoError(t, store.MergeIndexes([]dhstore.Index{{Key: mh, Value: []byte("fish")}}))
 			},
 			onMethod:     http.MethodGet,
 			onTarget:     "/multihash/2wvdp9y1J63yDvaPawP4kUjXezRLcu9x9u2DAB154dwai82",
@@ -183,9 +183,11 @@ func TestNewHttpServeMux(t *testing.T) {
 			onStore: func(t *testing.T, store dhstore.DHStore) {
 				mh, err := multihash.FromB58String("2wvdp9y1J63yDvaPawP4kUjXezRLcu9x9u2DAB154dwai82")
 				require.NoError(t, err)
-				require.NoError(t, store.MergeIndex(mh, []byte("fish")))
-				require.NoError(t, store.MergeIndex(mh, []byte("lobster")))
-				require.NoError(t, store.MergeIndex(mh, []byte("undadasea")))
+				require.NoError(t, store.MergeIndexes([]dhstore.Index{
+					{Key: mh, Value: []byte("fish")},
+					{Key: mh, Value: []byte("lobster")},
+					{Key: mh, Value: []byte("undadasea")},
+				}))
 			},
 			onMethod:     http.MethodGet,
 			onTarget:     "/multihash/2wvdp9y1J63yDvaPawP4kUjXezRLcu9x9u2DAB154dwai82",


### PR DESCRIPTION
Change the interface to take a slice of index records for merge instead of one at a time merges.

Reflect changes in FoundationDB and Pebble implementations.
 * In FoundationDB, use a single transaction for the entire merge.
 * In Pebble, use pebble batch insertion.