### PR TITLE
New pebble compaction configuration

### DIFF
--- a/.github/workflows/publish-ecr.yml
+++ b/.github/workflows/publish-ecr.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches:
       - main
-
+      - ivan/test-different-compaction-options
 jobs:
   publisher:
     if: ${{ github.event.pusher.name != 'sti-bot' }}

--- a/.github/workflows/publish-ecr.yml
+++ b/.github/workflows/publish-ecr.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches:
       - main
-      
+
 jobs:
   publisher:
     if: ${{ github.event.pusher.name != 'sti-bot' }}

--- a/.github/workflows/publish-ecr.yml
+++ b/.github/workflows/publish-ecr.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - main
+      
 jobs:
   publisher:
     if: ${{ github.event.pusher.name != 'sti-bot' }}

--- a/.github/workflows/publish-ecr.yml
+++ b/.github/workflows/publish-ecr.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches:
       - main
-      - ivan/test-different-compaction-options
 jobs:
   publisher:
     if: ${{ github.event.pusher.name != 'sti-bot' }}

--- a/cmd/dhstore/main.go
+++ b/cmd/dhstore/main.go
@@ -50,18 +50,14 @@ func main() {
 			panic(err)
 		}
 
-		// Default options copied from cockroachdb with the addition of 1GiB cache.
+		// Default options copied from cockroachdb with the addition of 1GiB cache and removing custom compaction options.
 		// See:
 		// - https://github.com/cockroachdb/cockroach/blob/v22.1.6/pkg/storage/pebble.go#L479
 		opts := &pebble.Options{
 			BytesPerSync:                10 << 20, // 10 MiB
 			WALBytesPerSync:             10 << 20, // 10 MiB
-			MaxConcurrentCompactions:    10,
 			MemTableSize:                64 << 20, // 64 MiB
 			MemTableStopWritesThreshold: 4,
-			LBaseMaxBytes:               64 << 20, // 64 MiB
-			L0CompactionThreshold:       2,
-			L0StopWritesThreshold:       1000,
 			DisableWAL:                  *dwal,
 			WALMinSyncInterval:          func() time.Duration { return 30 * time.Second },
 		}

--- a/cmd/dhstore/main.go
+++ b/cmd/dhstore/main.go
@@ -56,9 +56,12 @@ func main() {
 		opts := &pebble.Options{
 			BytesPerSync:                10 << 20, // 10 MiB
 			WALBytesPerSync:             10 << 20, // 10 MiB
+			MaxConcurrentCompactions:    10,
 			MemTableSize:                64 << 20, // 64 MiB
 			MemTableStopWritesThreshold: 4,
+			LBaseMaxBytes:               64 << 20, // 64 MiB
 			DisableWAL:                  *dwal,
+			L0CompactionThreshold:       2,
 			WALMinSyncInterval:          func() time.Duration { return 30 * time.Second },
 		}
 


### PR DESCRIPTION
The reason for this change is that lately pebble started to get imbalanced very often. Some of the compaction related parameters were a few X off from the default ones.

* CockroachDB's `L0StopWritesThreshold` of 1000 is unusable for our Pebble set up. Writes get never stopped even when the LSM tree gets completely out of balance and becomes unusable. Setting it to the default value of 12 have proved to be good enough - the LSM tree parameters stay at the half of their allowed  maximum values, while Pebble maintains a consistent throughout of 40-60k multihashes per second. Exposing `L0StopWritesThreshold` into the `dhstore` runtime parameters to tweak it up for our setting (theoretically we have a room to increase it to 18-20).
* Pebble's default `MaxConcurrentCompactions` of 1 is also unusable for our setup. While the LSM tree parameters stay stable, the compaction debt grows and eventually writes get forcefully stopped. With just one compactor running the database can never compact itself out. Others seem to have [hit](https://github.com/cockroachdb/pebble/issues/1691#issuecomment-1190467051) that issue too. As a rule of thumb it should be set to the number of CPU cores available - exposing it as a configuration option.

My observations over the weekend - the current configuration is deployed to both dev and prod. Write throughput stays around 40-60k multihashes per second. With 10 compaction workers and the rest of the compaction-related settings left at the default values Pebble handles 8 concurrent ingest workers in prod and 15 in dev. I think the number of concurrent writes is not an issue anymore. The reads have improved significantly too and show much more stable latencies. That was achieved at the cost of more often write latency spikes as Pebble has to compact more often. LSM tree parameters stay stable and compaction debt stays flat after I increased the number of compactors to 10. That means that the database is well balanced and can catch up with the number of compactions for the number of writes.  