### PR TITLE
Track dhfind latency

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -85,9 +85,9 @@ func (m *Metrics) RecordHttpLatency(ctx context.Context, t time.Duration, method
 		attribute.String("method", method), attribute.String("path", path), attribute.Int("status", status))
 }
 
-func (m *Metrics) RecordDHFindLatency(ctx context.Context, t time.Duration, method, path string, status int) {
+func (m *Metrics) RecordDHFindLatency(ctx context.Context, t time.Duration, method, path string, status int, firstResult bool) {
 	m.dhfindLatency.Record(ctx, t.Milliseconds(),
-		attribute.String("method", method), attribute.String("path", path), attribute.Int("status", status))
+		attribute.String("method", method), attribute.String("path", path), attribute.Int("status", status), attribute.Bool("ttfr", firstResult))
 }
 
 func (m *Metrics) Start(_ context.Context) error {


### PR DESCRIPTION
The metric is tracked as `"ipni/dhstore/dhfind_latency"`. This is different from the previous dhfind metric that was tracked as `"ipni/dhfind/http_latency"`. Consider which we want as using the new one will require queries for this metric to change.

- Fixes error that always passed OK status to dhfind metric
- Do not get start time and construct wrappers if not using metrics.