### PR TITLE
Add flags to set max threads and control Pebble compaction parameters

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -53,7 +53,9 @@ func newResponseWriterWithStatus(w http.ResponseWriter) *responseWriterWithStatu
 
 func (rec *responseWriterWithStatus) WriteHeader(code int) {
 	rec.status = code
-	rec.ResponseWriter.WriteHeader(code)
+	if code != http.StatusOK {
+		rec.ResponseWriter.WriteHeader(code)
+	}
 }
 
 func New(dhs dhstore.DHStore, addr string, options ...Option) (*Server, error) {
@@ -295,7 +297,7 @@ func (s *Server) handlePutMhs(w http.ResponseWriter, r *http.Request) {
 		s.handleError(w, err)
 		return
 	}
-	log.Infow("Finished putting multihashes", "count", len(mir.Merges), "sample", mir.Merges[0].Key.B58String())
+	log.Debugw("Finished putting multihashes", "count", len(mir.Merges), "sample", mir.Merges[0].Key.B58String())
 
 	w.WriteHeader(http.StatusAccepted)
 }


### PR DESCRIPTION
Add flags to set experimental compaction parallelism flags in pebble both for the number of concurrent compaction and the size of compaction.

Add env var to set max number of go OS threads.

Reduce log verbosity in HTTP server and fix superfluous header setting when status is 200.