### PR TITLE
Build without FDB support if built with -tags nofdb

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ To install `dhstore` CLI directly via Golang, run:
 $ go install github.com/ipni/dhstore/cmd/dhstore@latest
 ```
 
+To install `dhstore` without FDB support, run:
+
+```shell
+$ go install -tags nofdb github.com/ipni/dhstore/cmd/dhstore@latest
+```
+
 ## License
 
 [SPDX-License-Identifier: Apache-2.0 OR MIT](LICENSE.md)

--- a/cmd/dhstore/main.go
+++ b/cmd/dhstore/main.go
@@ -1,3 +1,6 @@
+// To build without FDB support, run the command:
+//
+//	go build -tags nofdb ./cmd/dhstore
 package main
 
 import (
@@ -16,7 +19,6 @@ import (
 	"github.com/cockroachdb/pebble/bloom"
 	logging "github.com/ipfs/go-log/v2"
 	"github.com/ipni/dhstore"
-	"github.com/ipni/dhstore/fdb"
 	"github.com/ipni/dhstore/metrics"
 	dhpebble "github.com/ipni/dhstore/pebble"
 	"github.com/ipni/dhstore/server"
@@ -63,8 +65,6 @@ func main() {
 
 	llvl := flag.String("logLevel", "info", "The logging level. Only applied if GOLOG_LOG_LEVEL environment variable is unset.")
 	storeType := flag.String("storeType", "pebble", "The store type to use. only `pebble` and `fdb` is supported. Defaults to `pebble`. When `fdb` is selected, all `fdb*` args must be set.")
-	fdbApiVersion := flag.Int("fdbApiVersion", 0, "Required. The FoundationDB API version as a numeric value")
-	fdbClusterFile := flag.String("fdbClusterFile", "", "Required. Path to ")
 	version := flag.Bool("version", false, "Show version information,")
 
 	flag.Parse()
@@ -139,7 +139,7 @@ func main() {
 		log.Infow("Store opened.", "path", path)
 	case "fdb":
 		var err error
-		store, err = fdb.NewFDBDHStore(fdb.WithApiVersion(*fdbApiVersion), fdb.WithClusterFile(*fdbClusterFile))
+		store, err = newFDBDHStore()
 		if err != nil {
 			panic(err)
 		}

--- a/cmd/dhstore/main_fdb.go
+++ b/cmd/dhstore/main_fdb.go
@@ -9,8 +9,8 @@ import (
 	"github.com/ipni/dhstore/fdb"
 )
 
-var fdbApiVersion int
-var fdbClusterFile string
+var fdbApiVersion *int
+var fdbClusterFile *string
 
 func init() {
 	fdbApiVersion = flag.Int("fdbApiVersion", 0, "Required. The FoundationDB API version as a numeric value")

--- a/cmd/dhstore/main_fdb.go
+++ b/cmd/dhstore/main_fdb.go
@@ -1,0 +1,22 @@
+//go:build !nofdb
+
+package main
+
+import (
+	"flag"
+
+	"github.com/ipni/dhstore"
+	"github.com/ipni/dhstore/fdb"
+)
+
+var fdbApiVersion int
+var fdbClusterFile string
+
+func init() {
+	fdbApiVersion = flag.Int("fdbApiVersion", 0, "Required. The FoundationDB API version as a numeric value")
+	fdbClusterFile = flag.String("fdbClusterFile", "", "Required. Path to ")
+}
+
+func newFDBDHStore() (dhstore.DHStore, error) {
+	return fdb.NewFDBDHStore(fdb.WithApiVersion(*fdbApiVersion), fdb.WithClusterFile(*fdbClusterFile))
+}

--- a/cmd/dhstore/main_nofdb.go
+++ b/cmd/dhstore/main_nofdb.go
@@ -1,0 +1,13 @@
+//go:build nofdb
+
+package main
+
+import (
+	"errors"
+
+	"github.com/ipni/dhstore"
+)
+
+func newFDBDHStore() (dhstore.DHStore, error) {
+	return nil, errors.New("dhstore built without fdb support")
+}


### PR DESCRIPTION
This allows testing on systems that do not have the necessary FDB dependencies.