### PR TITLE
Allow manual upgrade to latest pebble format

### DIFF
--- a/cmd/dhstore/main.go
+++ b/cmd/dhstore/main.go
@@ -107,6 +107,7 @@ func main() {
 			L0CompactionFileThreshold:   *l0CompactionFileThreshold,
 			DisableWAL:                  *dwal,
 			WALMinSyncInterval:          func() time.Duration { return 30 * time.Second },
+			FormatMajorVersion:          pebble.FormatNewest,
 		}
 
 		opts.Experimental.ReadCompactionRate = 10 << 20 // 20 MiB


### PR DESCRIPTION
- Need a way to upgrade the pebble database format for existing dhstore instances.
  - We need to update the format in use to something newer, before upgrading to pebble/v2, because the version in use in cid.contact sites is no longer compatible with pebble/v2.
  - We want to deploy this capability without forcing an immediate upgrade to the latest version, in case it is necessary to revert to a previous version of dhstore for some reason. Instead of automatic upgrade, an administrator will change the value specified by the `formatMajorVersion` cli flag  when it is determined reverting the dhstore update is not needed..

There is a new cli flag, `formatMajorVersion`. that sets the format of pebble on-disk files. Unset or 0 uses the current version. The help text for this flag shows the latest supported version.