### PR TITLE
Fix pebble cache unref

### DIFF
--- a/cmd/dhstore/main.go
+++ b/cmd/dhstore/main.go
@@ -160,7 +160,9 @@ func main() {
 			l.EnsureDefaults()
 		}
 		opts.Levels[numLevels-1].FilterPolicy = nil
-		opts.Cache = pebble.NewCache(int64(parsedBlockCacheSize))
+		blockCache := pebble.NewCache(int64(parsedBlockCacheSize))
+		defer blockCache.Unref()
+		opts.Cache = blockCache
 
 		path := filepath.Clean(*storePath)
 		pbstore, err := dhpebble.NewPebbleDHStore(path, opts)


### PR DESCRIPTION
Avoid potential memory leak by unrefing the cache after db is instantiated. This might be the root cause of OOM killed errors.